### PR TITLE
chore: add rbf script, remove old lib updates for wallets

### DIFF
--- a/wallets/bch-update.sh
+++ b/wallets/bch-update.sh
@@ -8,32 +8,22 @@ echo "Updating Bitcoin Cash. This may take a minute..."
 supervisorctl stop bitcoincash >> ${LOG_FILE} 2>&1
 echo
 
-echo "Downloading v0.21.7..."
-curl -#o /tmp/bitcoincash.tar.gz https://download.bitcoinabc.org/0.21.7/linux/bitcoin-abc-0.21.7-x86_64-linux-gnu.tar.gz >> ${LOG_FILE} 2>&1
+echo "Downloading Bitcoin Cash Node v22.1.0..."
+curl -#Lo /tmp/bitcoincash.tar.gz https://github.com/bitcoin-cash-node/bitcoin-cash-node/releases/download/v22.1.0/bitcoin-cash-node-22.1.0-x86_64-linux-gnu.tar.gz >> ${LOG_FILE} 2>&1
 tar -xzf /tmp/bitcoincash.tar.gz -C /tmp/ >> ${LOG_FILE} 2>&1
 echo
 
 echo "Updating wallet..."
 mv /usr/local/bin/bitcoincashd /usr/local/bin/bitcoincashd-old >> ${LOG_FILE} 2>&1
 mv /usr/local/bin/bitcoincash-cli /usr/local/bin/bitcoin-cli-old >> ${LOG_FILE} 2>&1
-cp /tmp/bitcoin-abc-0.21.7/bin/bitcoind /usr/local/bin/bitcoincashd >> ${LOG_FILE} 2>&1
-cp /tmp/bitcoin-abc-0.21.7/bin/bitcoin-cli /usr/local/bin/bitcoincash-cli >> ${LOG_FILE} 2>&1
-rm -r /tmp/bitcoin-abc-0.21.7 >> ${LOG_FILE} 2>&1
+cp /tmp/bitcoin-cash-node-22.1.0/bin/bitcoind /usr/local/bin/bitcoincashd >> ${LOG_FILE} 2>&1
+cp /tmp/bitcoin-cash-node-22.1.0/bin/bitcoin-cli /usr/local/bin/bitcoincash-cli >> ${LOG_FILE} 2>&1
+rm -r /tmp/bitcoin-cash-node-22.1.0 >> ${LOG_FILE} 2>&1
 rm /tmp/bitcoincash.tar.gz >> ${LOG_FILE} 2>&1
 echo
 
-echo "Updating wallet plugins..."
-curl -#o $(npm root -g)/lamassu-server/lib/admin/funding.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/admin/funding.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoincashd/bitcoincashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoincashd/bitcoincashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoind/bitcoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoind/bitcoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/dashd/dashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/dashd/dashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/litecoind/litecoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/litecoind/litecoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/zcashd/zcashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/zcashd/zcashd.js >> ${LOG_FILE} 2>&1
-
-sed -i 's/\<connections\>/maxconnections/g' /mnt/blockchains/bitcoincash/bitcoincash.conf >> ${LOG_FILE} 2>&1
-
+echo "Starting wallet..."
 supervisorctl start bitcoincash >> ${LOG_FILE} 2>&1
-supervisorctl restart lamassu-server lamassu-admin-server >> ${LOG_FILE} 2>&1
 echo
 
 echo "Bitcoin Cash is updated."

--- a/wallets/bchn-update.sh
+++ b/wallets/bchn-update.sh
@@ -22,17 +22,8 @@ rm -r /tmp/bitcoin-cash-node-22.1.0 >> ${LOG_FILE} 2>&1
 rm /tmp/bitcoincash.tar.gz >> ${LOG_FILE} 2>&1
 echo
 
-echo "Updating wallet plugins..."
-curl -#o $(npm root -g)/lamassu-server/lib/admin/funding.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/admin/funding.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoincashd/bitcoincashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoincashd/bitcoincashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoind/bitcoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoind/bitcoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/dashd/dashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/dashd/dashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/litecoind/litecoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/litecoind/litecoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/zcashd/zcashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/zcashd/zcashd.js >> ${LOG_FILE} 2>&1
-sed -i 's/\<connections\>/maxconnections/g' /mnt/blockchains/bitcoincash/bitcoincash.conf >> ${LOG_FILE} 2>&1
-
+echo "Starting wallet..."
 supervisorctl start bitcoincash >> ${LOG_FILE} 2>&1
-supervisorctl restart lamassu-server lamassu-admin-server >> ${LOG_FILE} 2>&1
 echo
 
 echo "Bitcoin Cash is updated."

--- a/wallets/btc-update.sh
+++ b/wallets/btc-update.sh
@@ -23,16 +23,8 @@ rm -r /tmp/bitcoin-0.20.1 >> ${LOG_FILE} 2>&1
 rm /tmp/bitcoin.tar.gz >> ${LOG_FILE} 2>&1
 echo
 
-echo "Updating wallet plugins..."
-curl -#o $(npm root -g)/lamassu-server/lib/admin/funding.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/admin/funding.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoincashd/bitcoincashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoincashd/bitcoincashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoind/bitcoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoind/bitcoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/dashd/dashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/dashd/dashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/litecoind/litecoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/litecoind/litecoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/zcashd/zcashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/zcashd/zcashd.js >> ${LOG_FILE} 2>&1
-
+echo "Starting wallet..."
 supervisorctl start bitcoin >> ${LOG_FILE} 2>&1
-supervisorctl restart lamassu-server lamassu-admin-server >> ${LOG_FILE} 2>&1
 echo
 
 echo "Bitcoin Core is updated."

--- a/wallets/conf/btc-enable-rbf.sh
+++ b/wallets/conf/btc-enable-rbf.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+export LOG_FILE=/tmp/btc-rbf-enable.$(date +"%Y%m%d").log
+
+echo
+echo "Updating Bitcoin Core to use RBF..."
+supervisorctl stop bitcoin >> ${LOG_FILE} 2>&1
+echo
+
+if grep -xq "walletrbf=." /mnt/blockchains/bitcoin/bitcoin.conf
+then
+    echo "RBF setting already defined, skipping..."
+else
+    echo "Enabling RBF in config file..."
+    echo -e "\nwalletrbf=1" >> /mnt/blockchains/bitcoin/bitcoin.conf
+fi
+echo
+
+echo "Done. Restarting Bitcoin Core..."
+supervisorctl start bitcoin >> ${LOG_FILE} 2>&1
+echo
+
+echo "Complete. Please refer to our knoweledgebase article on using fee bumping with RBF."
+echo

--- a/wallets/dash-update.sh
+++ b/wallets/dash-update.sh
@@ -8,17 +8,17 @@ echo "Updating Dash Core. This may take a minute."
 supervisorctl stop dash >> ${LOG_FILE} 2>&1
 
 echo
-echo "Downloading Dash Core v0.16.0.1..."
-curl -#Lo /tmp/dash.tar.gz https://github.com/dashpay/dash/releases/download/v0.16.0.1/dashcore-0.16.0.1-x86_64-linux-gnu.tar.gz >> ${LOG_FILE} 2>&1
+echo "Downloading Dash Core v0.16.1.1..."
+curl -#Lo /tmp/dash.tar.gz https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz >> ${LOG_FILE} 2>&1
 tar -xzf /tmp/dash.tar.gz -C /tmp/ >> ${LOG_FILE} 2>&1
 
 echo
 echo "Updating..."
 mv /usr/local/bin/dashd /usr/local/bin/dashd-old >> ${LOG_FILE} 2>&1
 mv /usr/local/bin/dash-cli /usr/local/bin/dash-cli-old >> ${LOG_FILE} 2>&1
-cp /tmp/dashcore-0.16.0/bin/dashd /usr/local/bin/dashd >> ${LOG_FILE} 2>&1
-cp /tmp/dashcore-0.16.0/bin/dash-cli /usr/local/bin/dash-cli >> ${LOG_FILE} 2>&1
-rm -r /tmp/dashcore-0.16.0 >> ${LOG_FILE} 2>&1
+cp /tmp/dashcore-0.16.1/bin/dashd /usr/local/bin/dashd >> ${LOG_FILE} 2>&1
+cp /tmp/dashcore-0.16.1/bin/dash-cli /usr/local/bin/dash-cli >> ${LOG_FILE} 2>&1
+rm -r /tmp/dashcore-0.16.1 >> ${LOG_FILE} 2>&1
 rm /tmp/dash.tar.gz >> ${LOG_FILE} 2>&1
 
 echo
@@ -36,8 +36,11 @@ else
     echo "Setting PrivateSend AutoStart in config file..."
     echo -e "privatesendautostart=1" >> /mnt/blockchains/dash/dash.conf
 fi
-
 echo
+
+echo "Starting wallet..."
 supervisorctl start dash >> ${LOG_FILE} 2>&1
+echo
+
 echo "Dash Core is updated."
 echo

--- a/wallets/eth-update.sh
+++ b/wallets/eth-update.sh
@@ -4,21 +4,25 @@ set -e
 export LOG_FILE=/tmp/eth-update.$(date +"%Y%m%d").log
 
 echo
-echo "Updating Ethereum. This may take a minute."
+echo "Updating the Geth Ethereum wallet. This may take a minute."
 supervisorctl stop ethereum >> ${LOG_FILE} 2>&1
-
 echo
-echo "Downloading..."
-curl -#o /tmp/ethereum.tar.gz https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.23-8c2f2715.tar.gz >> ${LOG_FILE} 2>&1
+
+echo "Downloading Geth v1.9.24..."
+curl -#o /tmp/ethereum.tar.gz https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.24-cc05b050.tar.gz >> ${LOG_FILE} 2>&1
 tar -xzf /tmp/ethereum.tar.gz -C /tmp/ >> ${LOG_FILE} 2>&1
-
 echo
+
 echo "Updating..."
 mv /usr/local/bin/geth /usr/local/bin/geth-old >> ${LOG_FILE} 2>&1
-cp /tmp/geth-linux-amd64-1.9.23-8c2f2715/geth /usr/local/bin/geth >> ${LOG_FILE} 2>&1
-rm -r /tmp/geth-linux-amd64-1.9.23-8c2f2715/ >> ${LOG_FILE} 2>&1
+cp /tmp/geth-linux-amd64-1.9.24-cc05b050/geth /usr/local/bin/geth >> ${LOG_FILE} 2>&1
+rm -r /tmp/geth-linux-amd64-1.9.24-cc05b050/ >> ${LOG_FILE} 2>&1
 rm /tmp/ethereum.tar.gz >> ${LOG_FILE} 2>&1
-supervisorctl start ethereum >> ${LOG_FILE} 2>&1
-
 echo
-echo "Ethereum is updated."
+
+echo "Starting wallet..."
+supervisorctl start ethereum >> ${LOG_FILE} 2>&1
+echo
+
+echo "Geth is updated."
+echo

--- a/wallets/ltc-update.sh
+++ b/wallets/ltc-update.sh
@@ -23,16 +23,8 @@ rm -r /tmp/litecoin-0.18.1 >> ${LOG_FILE} 2>&1
 rm /tmp/litecoin.tar.gz >> ${LOG_FILE} 2>&1
 echo
 
-echo "Updating wallet plugins..."
-curl -#o $(npm root -g)/lamassu-server/lib/admin/funding.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/admin/funding.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoincashd/bitcoincashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoincashd/bitcoincashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/bitcoind/bitcoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/bitcoind/bitcoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/dashd/dashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/dashd/dashd.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/litecoind/litecoind.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/litecoind/litecoind.js >> ${LOG_FILE} 2>&1
-curl -#o $(npm root -g)/lamassu-server/lib/plugins/wallet/zcashd/zcashd.js https://raw.githubusercontent.com/lamassu/lamassu-server/defiant-dingirma/lib/plugins/wallet/zcashd/zcashd.js >> ${LOG_FILE} 2>&1
-
+echo "Starting wallet..."
 supervisorctl start litecoin >> ${LOG_FILE} 2>&1
-supervisorctl restart lamassu-server lamassu-admin-server >> ${LOG_FILE} 2>&1
 echo
 
 echo "Litecoin Core is updated."


### PR DESCRIPTION
- adds script to enable RBF
- removes old lib updates
- removes restarts to l-s & l-a-s
- makes ZEC script v7.5-compatible
- merges BCH & BCHN scripts